### PR TITLE
Fix selection cleanup on completion

### DIFF
--- a/MacTodo/TodoManager.swift
+++ b/MacTodo/TodoManager.swift
@@ -96,6 +96,7 @@ class TodoManager: ObservableObject {
                 tasks[index].completionDate = Date()
             }
         }
+        selectedTaskIds.removeAll()
     }
     
     func deleteSelectedTasks() {
@@ -108,6 +109,7 @@ class TodoManager: ObservableObject {
             tasks[index].isCompleted = true
             tasks[index].completionDate = Date()
         }
+        selectedTaskIds.removeAll()
     }
     
     // MARK: - 持久化


### PR DESCRIPTION
## Summary
- clear selected tasks after completing selected or all tasks

## Testing
- `swift build -c release` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6840ff203b84832386f3885ec43ae038